### PR TITLE
fix wormhole on gravity 6.1.21

### DIFF
--- a/build.go
+++ b/build.go
@@ -43,9 +43,9 @@ var (
 	registryImage = env("WORM_REGISTRY_IMAGE", "quay.io/gravitational/wormhole-dev")
 
 	// baseImage is the base OS image to use for wormhole containers
-	baseImage = "ubuntu:18.10"
+	baseImage = "ubuntu:19.10"
 	// wireguardBuildImage is the docker image to use to build the wg cli tool
-	wireguardBuildImage = "ubuntu:18.10"
+	wireguardBuildImage = "ubuntu:19.10"
 	// rigImage is the imageref to get the rigging tool from
 	rigImage = "quay.io/gravitational/rig:6.0.1"
 

--- a/cmd/wormhole/controller.go
+++ b/cmd/wormhole/controller.go
@@ -194,7 +194,7 @@ func runController(cmd *cobra.Command, args []string) error {
 // If the /host/opt/cni/bin directory exists, copy the plugins to the host
 func syncCniBin() error {
 	if _, err := os.Stat("/host/opt/cni/bin"); !os.IsNotExist(err) {
-		err = sh.Run("bash", "-c", "cp /opt/cni/bin/* /host/opt/cni/bin/")
+		err = sh.Run("bash", "-c", "chown root:root -R /host/opt/cni/bin && cp /opt/cni/bin/* /host/opt/cni/bin/")
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/docs/generic-wormhole.yaml
+++ b/docs/generic-wormhole.yaml
@@ -255,6 +255,9 @@ spec:
               name: cni-net-dir
             - mountPath: /tmp
               name: tmpfs
+            # Used for iptables lock
+            - mountPath: /run
+              name: run
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
@@ -264,5 +267,8 @@ spec:
           hostPath:
             path: /etc/cni/net.d
         - name: tmpfs
+          emptyDir:
+            medium: Memory
+        - name: run
           emptyDir:
             medium: Memory

--- a/docs/gravity-wormhole.yaml
+++ b/docs/gravity-wormhole.yaml
@@ -227,6 +227,9 @@ spec:
               name: container-environment
             - mountPath: /tmp
               name: tmpfs
+            # Used for iptables lock
+            - mountPath: /run
+              name: run
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
@@ -239,5 +242,8 @@ spec:
           hostPath:
             path: /etc/container-environment
         - name: tmpfs
+          emptyDir:
+            medium: Memory
+        - name: run
           emptyDir:
             medium: Memory

--- a/docs/kube-wormhole.yaml
+++ b/docs/kube-wormhole.yaml
@@ -254,6 +254,9 @@ spec:
               name: cni-net-dir
             - mountPath: /tmp
               name: tmpfs
+            # Used for iptables lock
+            - mountPath: /run
+              name: run
       volumes:
         # Used to install CNI.
         - name: cni-bin-dir
@@ -263,5 +266,8 @@ spec:
           hostPath:
             path: /etc/cni/net.d
         - name: tmpfs
+          emptyDir:
+            medium: Memory
+        - name: run
           emptyDir:
             medium: Memory


### PR DESCRIPTION
- Fixes an issue where planet is getting created with /opt/bin/planet us planet uid and not root. So chown the directory to root before copying.
- Also, updates ubuntu base image due to upstream changes preventing updates of the security package
- Also add's /run as a tmpfs mount, since new version of iptables tries to take a lock and expects /run to be writable.