### PR TITLE
Update cni.go

### DIFF
--- a/pkg/controller/cni.go
+++ b/pkg/controller/cni.go
@@ -73,6 +73,10 @@ func (d *controller) configureCNI() error {
 	if err != nil {
 		return trace.Wrap(err).AddField("dir", filepath.Dir(path))
 	}
+	err = os.Chown(path, 0, 0)
+	if err != nil {
+		return trace.Wrap(err).AddField("path", path)
+	}
 
 	err = ioutil.WriteFile(path, jsonConf, 0644)
 	if err != nil {


### PR DESCRIPTION
Chown both the parent directory and the file when creating the cni configuration, as the underlying permissions may have changed.